### PR TITLE
[3460][IMP] base_tier_validation, sale_tier_validation: fix sending email & fix required validation on 'sent' state issue

### DIFF
--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -245,6 +245,7 @@ class TierValidation(models.AbstractModel):
                 in (self._state_to + [self._cancel_state])
                 and not rec._check_allow_write_under_validation(vals)
                 and not rec._context.get("skip_validation_check")
+                and rec.need_validation is True
             ):
                 raise ValidationError(_("The operation is under validation."))
         if vals.get(self._state_field) in self._state_from:

--- a/base_tier_validation/models/tier_validation.py
+++ b/base_tier_validation/models/tier_validation.py
@@ -245,7 +245,7 @@ class TierValidation(models.AbstractModel):
                 in (self._state_to + [self._cancel_state])
                 and not rec._check_allow_write_under_validation(vals)
                 and not rec._context.get("skip_validation_check")
-                and rec.need_validation is True
+                and rec.need_validation
             ):
                 raise ValidationError(_("The operation is under validation."))
         if vals.get(self._state_field) in self._state_from:

--- a/sale_tier_validation/models/sale_order.py
+++ b/sale_tier_validation/models/sale_order.py
@@ -7,8 +7,8 @@ from odoo import models
 class SaleOrder(models.Model):
     _name = "sale.order"
     _inherit = ["sale.order", "tier.validation"]
-    _state_from = ["draft", "sent", "to approve"]
-    _state_to = ["sale", "approved"]
+    _state_from = ["draft", "to approve"]
+    _state_to = ["sale", "sent", "approved"]
 
     _tier_validation_manual_config = False
 

--- a/sale_tier_validation/models/sale_order.py
+++ b/sale_tier_validation/models/sale_order.py
@@ -8,7 +8,7 @@ class SaleOrder(models.Model):
     _name = "sale.order"
     _inherit = ["sale.order", "tier.validation"]
     _state_from = ["draft", "to approve"]
-    _state_to = ["sale", "sent", "approved"]
+    _state_to = ["sent", "sale", "approved"]
 
     _tier_validation_manual_config = False
 


### PR DESCRIPTION
[3460](https://www.quartile.co/web#id=3460&cids=3&menu_id=505&action=1457&model=project.task&view_type=form)

As mentioned on commit message, this fix including updates of 'sent' state on sale order that previously require another validation to be not require another validation.
@AungKoKoLin1997 could you please help to improve the code as well to have update the need_validation field to True when in the "sent" state, one of the fields on sale order line is updated (e.g. product, qty, unit price) and fields on sale order like partner_id and pricelist_id is updated.

this is with assumption that any sale order in "sent" state should not require another validation process for confirming to sale order if there's no information updated.
but if any changes that related to prices and customer information, should require another validation process from manager for confirming the sale order.

If you have another idea is very welcome. lin. thank you